### PR TITLE
fix: 🐛 Persist stage alert

### DIFF
--- a/src/components/Alert.css
+++ b/src/components/Alert.css
@@ -16,6 +16,10 @@
   z-index: 2;
 }
 
+.alert.main-menu h1 {
+  font-size: 300px;
+}
+
 .alert .alert-content {
   align-self: center;
   width: 640px;

--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -12,7 +12,7 @@ class Alert extends React.Component {
     if (this.props.content !== prevProps.content) {
       if (this.props.autodismiss) {
         window.setTimeout(() => {
-          this.props.dismissAlert();
+          this.props.dismissAlert(this.props.name);
         }, 1500);
       }
     }

--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -59,7 +59,8 @@ class Alert extends React.Component {
       return (
         <div
           className={`alert
-          ${this.state.animatingOut ? "animating-out" : ""}`}
+          ${this.state.animatingOut ? "animating-out" : ""}
+          ${this.props.name}`}
         >
           <div className="alert-content">
             {content}

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -22,6 +22,10 @@ class App extends React.Component {
         content: <h1>Pozo</h1>,
         shown: true,
       },
+      stageAnnouncement: {
+        content: "Stage 1",
+        shown: false,
+      },
       instructions: {
         content: (
           <React.Fragment>
@@ -273,6 +277,13 @@ class App extends React.Component {
   monsterTimer = null;
   waveTimer = null;
 
+  updateAlert = (alertName, newAlertObject) => {
+    let alerts = this.state.alerts;
+    alerts[alertName] = { ...alerts[alertName], ...newAlertObject };
+
+    this.setState({ alerts });
+  };
+
   showAlert = (content, autodismiss = true, persistent = false) => {
     let alerts = this.state.alerts;
     let alert = this.state.alert;
@@ -316,6 +327,13 @@ class App extends React.Component {
           this.state.redAlert ? "red-alert" : ""
         }`}
       >
+        <Alert
+          content={this.state.alerts.stageAnnouncement.content}
+          shown={this.state.alerts.stageAnnouncement.shown}
+          name="stageAnnouncement"
+          autodismiss={true}
+          dismissAlert={this.dismissAlert}
+        ></Alert>
         <Alert
           name="main-menu"
           content={<h1>Pozo</h1>}
@@ -362,6 +380,7 @@ class App extends React.Component {
           changeGameActive={this.changeGameActive}
           isGameActive={this.state.gameActive}
           showAlert={this.showAlert}
+          updateAlert={this.updateAlert}
         />
       </div>
     );

--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -398,16 +398,14 @@ class Board extends React.Component {
     document.body.classList.add(`stage${stageNumber}`);
 
     // Number of monsters in stage (e.g., 50)
-    console.log("About to set state and timers");
     this.setState({ stageSettings }, setTimers);
     this.setState({
       monstersRemaining: stageSettings.monsters,
     });
-    this.props.showAlert(
-      <React.Fragment>
-        <h1>Stage {stageNumber}</h1>
-      </React.Fragment>
-    );
+    this.props.updateAlert("stageAnnouncement", {
+      content: <h1>{`Stage ${this.state.currentStage}`}</h1>,
+    });
+    this.props.showAlert("stageAnnouncement");
   };
 
   strike = (field, queue, strikeColor) => {

--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -353,7 +353,6 @@ class Board extends React.Component {
   };
 
   start = (stageNumber = 0) => {
-    console.log("Helllerrrr??");
     // Activate game
     this.setState({ gameActive: true, redAlert: false }, () => {
       if (stageNumber === 0) {
@@ -371,7 +370,6 @@ class Board extends React.Component {
 
     const stageSettings = { ...stages[stageNumber] },
       setTimers = () => {
-        console.log("Set the timers!");
         clearInterval(this.monsterTimer);
         clearInterval(this.waveTimer);
 

--- a/src/components/Menu.css
+++ b/src/components/Menu.css
@@ -26,7 +26,7 @@
   margin: 0;
 }
 
-.menu.main {
+.main-menu .menu {
   font-size: 48px;
 }
 


### PR DESCRIPTION
At some point, alerts could get dismissed by key press instead of needing to wait. This change fixes that.

Close #138 